### PR TITLE
Updating Signature Class 

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ You can also confirm the signature that you receive when you interacting with ou
 ```java
 import smile.identity.core.Signature;
 
-Signature connection = new Signature(partnerId, apiKey);
+Signature signature = new Signature(partnerId, apiKey);
 boolean signatureConfirmed = connection.confirmSignature(signature, timestamp);
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ The **ID Api Class** lets you performs basic KYC Services including verifying an
 - submit_job
 
 The **Signature Class** allows you as the Partner to generate a sec key to interact with our servers. It has the following public methods:
-- generate_sec_key
-- confirm_sec_key
-- generate_signature
-- confirm_signature
+- generateSignature
+- confirmSignature
 
 The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 - get_job_status
@@ -405,95 +403,35 @@ Your response will return a JSON String containing the below:
 
 #### Signature Class
 
-To calculate your sec key first import the necessary class:
-```java
-import smile.identity.core.Signature;
-```
-
-##### generate_sec_key method
-
-Then call the Signature class as follows:
-
-```java
-import smile.identity.core.Signature;
-
-try {
-  Signature connection = new Signature(partnerId, apiKey);
-  String signatureJsonStr = connection.generate_sec_key(timestamp); // where timestamp is optional
-
-  // In order to utilise the signature you can then use a json parser and extract the signature
-} catch (Exception e) {
-  e.printStackTrace();
-  throw e;
-}
-```
-
-The response will be a stringified json object:
-```java
-{
-  "sec_key": "<the generated sec key>",
-  "timestamp": "<timestamp that you passed in or that was generated>"
-}
-```
-
-##### confirm_sec_key method
-
-You can also confirm the sec key that you receive when you interacting with our servers, simply use the confirm_sec_key method which returns a boolean:
-
-```java
-import smile.identity.core.Signature;
-
-try {
-  Signature connection = new Signature(partnerId, apiKey);
-  String signatureJsonStr = connection.confirm_sec_key(secKey, timestamp);
-  // If it is valid then use the response, else throw an error
-} catch (Exception e) {
-  e.printStackTrace();
-  return false;
-}
-```
-
 
 To calculate your signature first import the necessary class:
 ```java
 import smile.identity.core.Signature;
 ```
 
-##### generate_signature method
+##### generateSignature method
 
 Then call the Signature class as follows:
 
 ```java
 import smile.identity.core.Signature;
 
-try {
   Signature connection = new Signature(partnerId, apiKey);
-  String signatureJsonStr = connection.generate_signature(timestamp); // where timestamp is optional
-
-  // In order to utilise the signature you can then use a json parser and extract the signature
-} catch (Exception e) {
-  e.printStackTrace();
-  throw e;
-}
+  SignatureKey key = connection.generateSignature(timestamp); // where timestamp is optional
+  Long timestamp = key.getTimestamp();
+  String signature = key.getSignature();
+  String timestampS = key.getformattedTimestamp();
 ```
 
-The response will be a stringified json object:
-```java
-{
-  "signature": "<the generated signature>",
-  "timestamp": "<timestamp that you passed in or that was generated>"
-}
-```
+##### confirmSignature method
 
-##### confirm_signature method
-
-You can also confirm the signature that you receive when you interacting with our servers, simply use the confirm_signature method which returns a boolean:
+You can also confirm the signature that you receive when you interacting with our servers, simply use the confirmSignature method which returns a boolean:
 
 ```java
 import smile.identity.core.Signature;
 
 Signature connection = new Signature(partnerId, apiKey);
-boolean signatureConfirmed = connection.confirm_signature(signature, timestamp);
+boolean signatureConfirmed = connection.confirmSignature(signature, timestamp);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -416,11 +416,11 @@ Then call the Signature class as follows:
 ```java
 import smile.identity.core.Signature;
 
-  Signature connection = new Signature(partnerId, apiKey);
-  SignatureKey key = connection.generateSignature(timestamp); // where timestamp is optional
-  Long timestamp = key.getTimestamp();
+  Signature signature = new Signature(partnerId, apiKey);
+  SignatureKey key = signature.generateSignature(timestamp); // where timestamp is optional
+  long timestamp = key.getTimestamp();
   String signature = key.getSignature();
-  String timestampS = key.getformattedTimestamp();
+  String timestampString = key.getformattedTimestamp();
 ```
 
 ##### confirmSignature method
@@ -431,7 +431,7 @@ You can also confirm the signature that you receive when you interacting with ou
 import smile.identity.core.Signature;
 
 Signature signature = new Signature(partnerId, apiKey);
-boolean signatureConfirmed = connection.confirmSignature(signature, timestamp);
+boolean signatureConfirmed = signature.confirmSignature(timestamp, "signature string");
 ```
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed 
+- Changed return object of getSignature method 
+- Updated documentation 
+
 ## [0.0.2] - 2019-08-12
 ### Added
 The first release version of Web Api.

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -20,7 +20,7 @@ public class Signature {
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 
-    public Boolean confirmSignature(long timestamp, String signature){
+    public boolean confirmSignature(long timestamp, String signature){
         SignatureKey key = new SignatureKey(timestamp, this.partnerId, this.apiKey);
         return key.validSignature(signature);
     }

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -20,7 +20,7 @@ public class Signature {
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 
-    public Boolean confirmSignature(Long timestamp, String signature){
+    public Boolean confirmSignature(long timestamp, String signature){
         SignatureKey key = new SignatureKey(timestamp, this.partnerId, this.apiKey);
         return key.validSignature(signature);
     }

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -20,10 +20,6 @@ public class Signature {
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 
-    public Boolean validateSignature(Long timestamp, String signature){
-        return confirmSignature(timestamp, signature);
-    }
-
     public Boolean confirmSignature(Long timestamp, String signature){
         SignatureKey key = new SignatureKey(timestamp, this.partnerId, this.apiKey);
         return key.validSignature(signature);

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -1,181 +1,31 @@
 package smile.identity.core;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.Mac;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.SecretKeySpec;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.security.spec.X509EncodedKeySpec;
-import java.text.SimpleDateFormat;
-import java.util.Base64;
+import smile.identity.core.keys.SignatureKey;
 
 public class Signature {
 
-    private static final String SHA_256 = "SHA-256";
-    private static final String HMAC_SHA_256 = "HmacSHA256";
-    public static final String SEC_KEY = "sec_key";
-    public static final String TIME_STAMP_KEY = "timestamp";
-    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    public static final String SIGNATURE_KEY = "signature";
-	
-    private String partnerId;
-    private String apiKey;
+    private final String partnerId;
+    private final String apiKey;
 
     public Signature(String partnerId, String apiKey) {
         this.partnerId = partnerId;
         this.apiKey = apiKey;
     }
-    
-	public String generate_signature() throws Exception {
-    	return generate_signature(System.currentTimeMillis());
-    }
-    
-	/***
-     *  Will generate a signature for the provided timestamp
-     * @param timestamp the timestamp to generate the signature from
-     * @return the JSON String containing both the signature and related timestamp
-	 * @throws NoSuchAlgorithmException 
-	 * @throws InvalidKeyException
-     */
-    @SuppressWarnings({ "unchecked" })
-	public String generate_signature(Long timestamp) throws NoSuchAlgorithmException, InvalidKeyException {
-    	JSONObject signatureObj = new JSONObject();
-    	signatureObj.put(TIME_STAMP_KEY, timestamp);
-    	
-    	Mac mac = Mac.getInstance(HMAC_SHA_256);
-        mac.init(new SecretKeySpec(apiKey.getBytes(), HMAC_SHA_256));
-		mac.update(new SimpleDateFormat(DATE_TIME_FORMAT).format(timestamp).getBytes(StandardCharsets.UTF_8));
-		mac.update(partnerId.getBytes(StandardCharsets.UTF_8));
-		mac.update("sid_request".getBytes(StandardCharsets.UTF_8));
-		
-		String signature = Base64.getEncoder().encodeToString(mac.doFinal());
-		signatureObj.put(SIGNATURE_KEY, signature);
-		
-		return signatureObj.toString();
+
+    public SignatureKey generateSignature() {
+        return generateSignature(System.currentTimeMillis());
     }
 
-    public String getSignature(Long timestamp) throws Exception {
-        JSONObject json = (JSONObject) new JSONParser().parse(generate_signature(timestamp));
-        return (String) json.get(SIGNATURE_KEY);
-    }
-    
-	/***
-     *  Will confirm the signature against a newly generated signature based on the same timestamp
-     * @param timestamp the timestamp to generate the signature from
-     * @param signature a previously generated signature, to be confirmed
-     * @return TRUE or FALSE
-     */
-    public Boolean confirm_signature(Long timestamp, String signature) {
-	    try {
-	    	JSONObject json = (JSONObject) new JSONParser().parse(generate_signature(timestamp));
-			return signature.equalsIgnoreCase((String) json.get(SIGNATURE_KEY));
-		} catch (NoSuchAlgorithmException|InvalidKeyException | ParseException e) {
-			return false;
-		}
+    public SignatureKey generateSignature(Long timestamp){
+        return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 
-    @SuppressWarnings({ "unchecked" })
-	public String generate_sec_key(Long timestamp) throws Exception {
-        String toHash = Integer.parseInt(partnerId) + ":" + timestamp;
-        String signature = "";
-        JSONObject signatureObj = new JSONObject();
-
-        try {
-            MessageDigest md = MessageDigest.getInstance(SHA_256);
-            md.update(toHash.getBytes());
-            byte[] hashed = md.digest();
-            String hashSignature = bytesToHexStr(hashed);
-
-            PublicKey publicKey = loadPublicKey(apiKey);
-            byte[] encSignature = encryptString(publicKey, hashSignature);
-            signature = Base64.getEncoder().encodeToString(encSignature) + "|" + hashSignature;
-        } catch (Exception e) {
-            throw e;
-        }
-
-        signatureObj.put(SEC_KEY, signature);
-        signatureObj.put(TIME_STAMP_KEY, timestamp);
-        
-        return signatureObj.toString();
+    public Boolean validateSignature(Long timestamp, String signature){
+        return confirmSignature(timestamp, signature);
     }
 
-    // we overload the method for the optional timestamp
-    public String generate_sec_key() throws Exception {
-        Long timestamp = System.currentTimeMillis();
-        return generate_sec_key(timestamp);
-    }
-    
-    public String getSecKey(Long timestamp) throws Exception {
-        JSONObject json = (JSONObject) new JSONParser().parse(generate_sec_key(timestamp));
-        return (String) json.get(SEC_KEY);
-    }
-
-    public Boolean confirm_sec_key(String timestamp, String secKey) throws Exception {
-        String toHash = Integer.parseInt(partnerId) + ":" + timestamp;
-        
-        try {
-            MessageDigest md = MessageDigest.getInstance(SHA_256);
-            md.update(toHash.getBytes());
-            byte[] hashed = md.digest();
-            String hashSignature = bytesToHexStr(hashed);
-
-            String[] arrOfStr = secKey.split("\\|");
-            String encrypted = arrOfStr[0];
-
-            PublicKey publicKey = loadPublicKey(apiKey);
-
-            byte[] decodedBytes = Base64.getDecoder().decode(encrypted);
-            String decrypted = decryptString(publicKey, decodedBytes);
-
-            return decrypted.equals(hashSignature);
-        } catch (Exception e) {
-            throw e;
-        }
-    }
-
-    public static Boolean useSignature(JSONObject options) {
-        if (options.containsKey(Signature.SIGNATURE_KEY)) {
-            return (Boolean) options.get(Signature.SIGNATURE_KEY);
-        }
-        return true;
-    }
-
-    private static PublicKey loadPublicKey(String apiKey) throws GeneralSecurityException, IOException {
-        apiKey = apiKey.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "").replace("\n", "").replace("\r", "").trim();
-        apiKey = apiKey.replaceAll(" ", "");
-        byte[] data = Base64.getDecoder().decode((apiKey.getBytes()));
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(data);
-        return KeyFactory.getInstance("RSA").generatePublic(spec);
-    }
-
-    private static byte[] encryptString(PublicKey key, String plaintext) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-        Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-        cipher.init(Cipher.ENCRYPT_MODE, key);
-        return cipher.doFinal(plaintext.getBytes());
-    }
-
-    private static String decryptString(PublicKey key, byte[] encrypted) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
-        Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-        cipher.init(Cipher.DECRYPT_MODE, key);
-        return new String(cipher.doFinal(encrypted));
-    }
-
-    private static String bytesToHexStr(byte[] bytes) {
-        StringBuilder sb = new StringBuilder();
-        
-        for (byte b : bytes) {
-            sb.append(String.format("%02x", b));
-        }
-        
-        return sb.toString();
+    public Boolean confirmSignature(Long timestamp, String signature){
+        SignatureKey key = new SignatureKey(timestamp, this.partnerId, this.apiKey);
+        return key.validSignature(signature);
     }
 }

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -16,7 +16,7 @@ public class Signature {
         return generateSignature(System.currentTimeMillis());
     }
 
-    public SignatureKey generateSignature(Long timestamp){
+    public SignatureKey generateSignature(long timestamp){
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -9,10 +9,10 @@ import java.util.Base64;
 
 public class SignatureKey {
 
-    private Long timestamp;
-    private String signature;
+    private final long timestamp;
+    private final String signature;
 
-    public SignatureKey(Long timestamp, String partnerId, String apiKey) {
+    public SignatureKey(long timestamp, String partnerId, String apiKey) {
         this.timestamp = timestamp;
         this.signature = generateKey(partnerId, apiKey);
     }
@@ -34,11 +34,11 @@ public class SignatureKey {
         return this.signature;
     }
 
-    public Long getTimestamp(){
+    public long getTimestamp(){
         return this.timestamp;
     }
 
-    public Boolean validSignature(String signature) {
+    public boolean validSignature(String signature) {
         return signature.equals(this.signature);
     }
 

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -14,17 +14,17 @@ public class SignatureKey {
 
     public SignatureKey(Long timestamp, String partnerId, String apiKey) {
         this.timestamp = timestamp;
-        generateKey(partnerId, apiKey);
+        this.signature = generateKey(partnerId, apiKey);
     }
 
-    private void generateKey(String partnerId, String apiKey) {
+    private String generateKey(String partnerId, String apiKey) {
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(apiKey.getBytes(), "HmacSHA256"));
             mac.update(formattedTimestamp().getBytes(StandardCharsets.UTF_8));
             mac.update(partnerId.getBytes(StandardCharsets.UTF_8));
             mac.update("sid_request".getBytes(StandardCharsets.UTF_8));
-            this.signature = Base64.getEncoder().encodeToString(mac.doFinal());
+            return Base64.getEncoder().encodeToString(mac.doFinal());
         } catch (GeneralSecurityException e){
             throw new RuntimeException(e);
         }

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -1,0 +1,49 @@
+package smile.identity.core.keys;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.util.Base64;
+
+public class SignatureKey {
+
+    private Long timestamp;
+    private String signature;
+
+    public SignatureKey(Long timestamp, String partnerId, String apiKey) {
+        this.timestamp = timestamp;
+        generateKey(partnerId, apiKey);
+    }
+
+    private void generateKey(String partnerId, String apiKey) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(apiKey.getBytes(), "HmacSHA256"));
+            mac.update(formattedTimestamp().getBytes(StandardCharsets.UTF_8));
+            mac.update(partnerId.getBytes(StandardCharsets.UTF_8));
+            mac.update("sid_request".getBytes(StandardCharsets.UTF_8));
+            this.signature = Base64.getEncoder().encodeToString(mac.doFinal());
+        } catch (GeneralSecurityException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getSignature(){
+        return this.signature;
+    }
+
+    public Long getTimestamp(){
+        return this.timestamp;
+    }
+
+    public Boolean validSignature(String signature) {
+        return signature.equals(this.signature);
+    }
+
+    public String formattedTimestamp(){
+        return Instant.ofEpochMilli(this.timestamp).toString();
+    }
+
+}

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -1,81 +1,29 @@
 package smile.identity.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Date;
-
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.junit.Before;
 import org.junit.Test;
+import smile.identity.core.keys.SignatureKey;
 
 public class SignatureTest {
-	
-    private String PARTNER_ID = "<PARTNER_ID>";
-    private String API_KEY = "<API_KEY>";
-    private Signature mSignature;
-	
-    @Before
-    public void setup() {
-    	mSignature = new Signature(PARTNER_ID, API_KEY);
-    }
-
-    @Test
-    public void testSignature() {
-    	JSONObject sigJsonObj = null;
-    	Long dateTime = new Date().getTime();
-    	
-    	try {
-        	sigJsonObj = (JSONObject) new JSONParser().parse(mSignature.generate_signature(dateTime));
-    	} catch (Exception e) {
-    		assertTrue(false);
-		}
-    	
-    	assertNotNull(sigJsonObj);
-    	assertTrue(sigJsonObj.containsKey(Signature.TIME_STAMP_KEY));
-    	
-    	Long dt = (Long) sigJsonObj.get(Signature.TIME_STAMP_KEY);
-    	assertEquals(dateTime, dt);
-    	
-    	assertTrue(sigJsonObj.containsKey(Signature.SIGNATURE_KEY));
-    	String signature = (String) sigJsonObj.get(Signature.SIGNATURE_KEY);
-    	assertTrue(!signature.isBlank());
-    	
-    	assertTrue(mSignature.confirm_signature(dateTime, signature));
-    }
 
 	@Test
-	public void testUseSignatureDefaultTrue(){
-		JSONObject options = new JSONObject();
-		Boolean useSignature = Signature.useSignature(options);
-		assert(useSignature).equals(true);
+	public void itGeneratesASignatureWhenNoTimestampProvided(){
+		Signature signature = new Signature("partner", "apiKey");
+		SignatureKey sk = signature.generateSignature();
+		assert!(sk.getSignature()).isEmpty();
 	}
 
 	@Test
-	public void testUseSignatureUseOptionFalse(){
-		JSONObject options = new JSONObject();
-		options.put(Signature.SIGNATURE_KEY, false);
-		Boolean useSignature = Signature.useSignature(options);
-		assert(useSignature).equals(false);
+	public void itGeneratesASignatureWhenTimestampProvided(){
+		Signature signature = new Signature("partner", "apiKey");
+		Long timestamp = System.currentTimeMillis();
+		SignatureKey sk = signature.generateSignature();
+		assert(sk.getTimestamp().equals(timestamp));
 	}
 
 	@Test
-	public void testUseSignatureUseOptionTrue(){
-		JSONObject options = new JSONObject();
-		options.put(Signature.SIGNATURE_KEY, true);
-		Boolean useSignature = Signature.useSignature(options);
-		assert(useSignature).equals(true);
+	public void itConfirmsASignature(){
+		Signature signature = new Signature("partner", "apiKey");
+		SignatureKey original = signature.generateSignature();
+		assert(signature.validateSignature(original.getTimestamp(), original.getSignature()));
 	}
-
-	@Test
-	public void testSignatureAndSecKeyPresent(){
-		JSONObject options = new JSONObject();
-		options.put(Signature.SIGNATURE_KEY, true);
-		options.put(Signature.SEC_KEY, true);
-		Boolean useSignature = Signature.useSignature(options);
-		assert(useSignature).equals(true);
-	}
-
 }

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -1,5 +1,6 @@
 package smile.identity.core;
 
+import org.junit.Assert;
 import org.junit.Test;
 import smile.identity.core.keys.SignatureKey;
 
@@ -9,21 +10,21 @@ public class SignatureTest {
 	public void itGeneratesASignatureWhenNoTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
 		SignatureKey sk = signature.generateSignature();
-		assert!(sk.getSignature()).isEmpty();
+		Assert.assertFalse(sk.getSignature().isEmpty());
 	}
 
 	@Test
 	public void itGeneratesASignatureWhenTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
-		Long timestamp = System.currentTimeMillis();
+		long timestamp = System.currentTimeMillis();
 		SignatureKey sk = signature.generateSignature();
-		assert(sk.getTimestamp().equals(timestamp));
+		Assert.assertEquals(sk.getTimestamp(), timestamp);
 	}
 
 	@Test
 	public void itConfirmsASignature(){
 		Signature signature = new Signature("partner", "apiKey");
 		SignatureKey original = signature.generateSignature();
-		assert(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
+		Assert.assertTrue(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
 	}
 }

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -24,6 +24,6 @@ public class SignatureTest {
 	public void itConfirmsASignature(){
 		Signature signature = new Signature("partner", "apiKey");
 		SignatureKey original = signature.generateSignature();
-		assert(signature.validateSignature(original.getTimestamp(), original.getSignature()));
+		assert(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
 	}
 }

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -1,8 +1,9 @@
 package smile.identity.core;
 
-import org.junit.Assert;
 import org.junit.Test;
 import smile.identity.core.keys.SignatureKey;
+
+import static org.junit.Assert.*;
 
 public class SignatureTest {
 
@@ -10,7 +11,7 @@ public class SignatureTest {
 	public void itGeneratesASignatureWhenNoTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
 		SignatureKey sk = signature.generateSignature();
-		Assert.assertFalse(sk.getSignature().isEmpty());
+		assertFalse(sk.getSignature().isEmpty());
 	}
 
 	@Test
@@ -18,13 +19,13 @@ public class SignatureTest {
 		Signature signature = new Signature("partner", "apiKey");
 		long timestamp = System.currentTimeMillis();
 		SignatureKey sk = signature.generateSignature();
-		Assert.assertEquals(sk.getTimestamp(), timestamp);
+		assertEquals(sk.getTimestamp(), timestamp);
 	}
 
 	@Test
 	public void itConfirmsASignature(){
 		Signature signature = new Signature("partner", "apiKey");
 		SignatureKey original = signature.generateSignature();
-		Assert.assertTrue(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
+		assertTrue(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
 	}
 }

--- a/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
+++ b/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
@@ -1,0 +1,42 @@
+package smile.identity.core.keys;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class SignatureKeyTest {
+
+    @Test
+    public void generateSignatureKey() {
+        Long timestamp = System.currentTimeMillis();
+        SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
+        assert (key.getSignature() != null);
+        assert (key.getTimestamp() != null);
+    }
+
+    @Test
+    public void validateSignature() {
+        Long timestamp = System.currentTimeMillis();
+        SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
+        assert (key.validSignature(key.getSignature()));
+    }
+
+    @Test
+    public void formatTimestamp() {
+        Long timestamp = System.currentTimeMillis();
+        SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
+        String timestampString = key.formattedTimestamp();
+        assert (validFormat(timestampString));
+    }
+
+    private boolean validFormat(String timestamp) {
+        try {
+            LocalDate.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (DateTimeParseException ex) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
+++ b/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
@@ -7,6 +7,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+import static org.junit.Assert.*;
+
 public class SignatureKeyTest {
 
     @Test
@@ -15,15 +17,15 @@ public class SignatureKeyTest {
         String signature = "KNDw4XBi92pINYzNu0Y4iXgXyTjDn2yoaoCg5z6pic0=";
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
 
-        Assert.assertEquals(signature, key.getSignature());
-        Assert.assertEquals(timestamp, key.getTimestamp());
+        assertEquals(signature, key.getSignature());
+        assertEquals(timestamp, key.getTimestamp());
     }
 
     @Test
     public void validateSignature() {
         long timestamp = System.currentTimeMillis();
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
-        assert (key.validSignature(key.getSignature()));
+        assertTrue(key.validSignature(key.getSignature()));
     }
 
     @Test
@@ -31,7 +33,7 @@ public class SignatureKeyTest {
         long timestamp = System.currentTimeMillis();
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
         String timestampString = key.formattedTimestamp();
-        assert (validFormat(timestampString));
+        assertTrue(validFormat(timestampString));
     }
 
     private boolean validFormat(String timestamp) {

--- a/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
+++ b/src/test/java/smile/identity/core/keys/SignatureKeyTest.java
@@ -1,5 +1,6 @@
 package smile.identity.core.keys;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDate;
@@ -10,22 +11,24 @@ public class SignatureKeyTest {
 
     @Test
     public void generateSignatureKey() {
-        Long timestamp = System.currentTimeMillis();
+        long timestamp = 1668090818630L;
+        String signature = "KNDw4XBi92pINYzNu0Y4iXgXyTjDn2yoaoCg5z6pic0=";
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
-        assert (key.getSignature() != null);
-        assert (key.getTimestamp() != null);
+
+        Assert.assertEquals(signature, key.getSignature());
+        Assert.assertEquals(timestamp, key.getTimestamp());
     }
 
     @Test
     public void validateSignature() {
-        Long timestamp = System.currentTimeMillis();
+        long timestamp = System.currentTimeMillis();
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
         assert (key.validSignature(key.getSignature()));
     }
 
     @Test
     public void formatTimestamp() {
-        Long timestamp = System.currentTimeMillis();
+        long timestamp = System.currentTimeMillis();
         SignatureKey key = new SignatureKey(timestamp, "partner", "apikey");
         String timestampString = key.formattedTimestamp();
         assert (validFormat(timestampString));


### PR DESCRIPTION
This PR is a complete refactor of the `Signature.class`. It introduces breaking changes.

## Changes
- new `SignatureKey` class
- moved key generating logic to `SignatureKey`
- removed SEC Key generation, we no longer support this and got the OK. 
- Signature.generateSignature() now returns a `SignatureKey`

## Testing 
- unit test 
