### PR TITLE
Renaming method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **ID Api Class** lets you performs basic KYC Services including verifying an
 - submit_job
 
 The **Signature Class** allows you as the Partner to generate a sec key to interact with our servers. It has the following public methods:
-- generateSignature
+- getSignature
 - confirmSignature
 
 The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
@@ -409,7 +409,7 @@ To calculate your signature first import the necessary class:
 import smile.identity.core.Signature;
 ```
 
-##### generateSignature method
+##### getSignature method
 
 Then call the Signature class as follows:
 
@@ -417,7 +417,7 @@ Then call the Signature class as follows:
 import smile.identity.core.Signature;
 
   Signature signature = new Signature(partnerId, apiKey);
-  SignatureKey key = signature.generateSignature(timestamp); // where timestamp is optional
+  SignatureKey key = signature.getSignature(timestamp); // where timestamp is optional
   long timestamp = key.getTimestamp();
   String signature = key.getSignature();
   String timestampString = key.getformattedTimestamp();
@@ -425,13 +425,13 @@ import smile.identity.core.Signature;
 
 ##### confirmSignature method
 
-You can also confirm the signature that you receive when you interacting with our servers, simply use the confirmSignature method which returns a boolean:
+Use the confirmSignature method to confirm the signature you receive while interacting with our servers.
 
 ```java
 import smile.identity.core.Signature;
 
 Signature signature = new Signature(partnerId, apiKey);
-boolean signatureConfirmed = signature.confirmSignature(timestamp, "signature string");
+boolean signatureConfirmed = signature.confirmSignature(timestamp, "receivedSignatureString");
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **ID Api Class** lets you performs basic KYC Services including verifying an
 - submit_job
 
 The **Signature Class** allows you as the Partner to generate a sec key to interact with our servers. It has the following public methods:
-- getSignature
+- getSignatureKey
 - confirmSignature
 
 The **Utilities Class** allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
@@ -409,7 +409,7 @@ To calculate your signature first import the necessary class:
 import smile.identity.core.Signature;
 ```
 
-##### getSignature method
+##### getSignatureKey method
 
 Then call the Signature class as follows:
 
@@ -417,7 +417,7 @@ Then call the Signature class as follows:
 import smile.identity.core.Signature;
 
   Signature signature = new Signature(partnerId, apiKey);
-  SignatureKey key = signature.getSignature(timestamp); // where timestamp is optional
+  SignatureKey key = signature.getSignatureKey(timestamp); // where timestamp is optional
   long timestamp = key.getTimestamp();
   String signature = key.getSignature();
   String timestampString = key.getformattedTimestamp();

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -12,11 +12,11 @@ public class Signature {
         this.apiKey = apiKey;
     }
 
-    public SignatureKey getSignature() {
-        return getSignature(System.currentTimeMillis());
+    public SignatureKey getSignatureKey() {
+        return getSignatureKey(System.currentTimeMillis());
     }
 
-    public SignatureKey getSignature(long timestamp){
+    public SignatureKey getSignatureKey(long timestamp){
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 

--- a/src/main/java/smile/identity/core/Signature.java
+++ b/src/main/java/smile/identity/core/Signature.java
@@ -12,11 +12,11 @@ public class Signature {
         this.apiKey = apiKey;
     }
 
-    public SignatureKey generateSignature() {
-        return generateSignature(System.currentTimeMillis());
+    public SignatureKey getSignature() {
+        return getSignature(System.currentTimeMillis());
     }
 
-    public SignatureKey generateSignature(long timestamp){
+    public SignatureKey getSignature(long timestamp){
         return new SignatureKey(timestamp, this.partnerId, this.apiKey);
     }
 

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -14,10 +14,10 @@ public class SignatureKey {
 
     public SignatureKey(long timestamp, String partnerId, String apiKey) {
         this.timestamp = timestamp;
-        this.signature = generateKey(partnerId, apiKey);
+        this.signature = generate(partnerId, apiKey);
     }
 
-    private String generateKey(String partnerId, String apiKey) {
+    private String generate(String partnerId, String apiKey) {
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(apiKey.getBytes(), "HmacSHA256"));

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -10,7 +10,7 @@ public class SignatureTest {
 	@Test
 	public void itGeneratesASignatureWhenNoTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
-		SignatureKey sk = signature.generateSignature();
+		SignatureKey sk = signature.getSignature();
 		assertFalse(sk.getSignature().isEmpty());
 	}
 
@@ -18,14 +18,14 @@ public class SignatureTest {
 	public void itGeneratesASignatureWhenTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
 		long timestamp = System.currentTimeMillis();
-		SignatureKey sk = signature.generateSignature();
+		SignatureKey sk = signature.getSignature(timestamp);
 		assertEquals(sk.getTimestamp(), timestamp);
 	}
 
 	@Test
 	public void itConfirmsASignature(){
 		Signature signature = new Signature("partner", "apiKey");
-		SignatureKey original = signature.generateSignature();
+		SignatureKey original = signature.getSignature();
 		assertTrue(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
 	}
 }

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -10,7 +10,7 @@ public class SignatureTest {
 	@Test
 	public void itGeneratesASignatureWhenNoTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
-		SignatureKey sk = signature.getSignature();
+		SignatureKey sk = signature.getSignatureKey();
 		assertFalse(sk.getSignature().isEmpty());
 	}
 
@@ -18,14 +18,14 @@ public class SignatureTest {
 	public void itGeneratesASignatureWhenTimestampProvided(){
 		Signature signature = new Signature("partner", "apiKey");
 		long timestamp = System.currentTimeMillis();
-		SignatureKey sk = signature.getSignature(timestamp);
+		SignatureKey sk = signature.getSignatureKey(timestamp);
 		assertEquals(sk.getTimestamp(), timestamp);
 	}
 
 	@Test
 	public void itConfirmsASignature(){
 		Signature signature = new Signature("partner", "apiKey");
-		SignatureKey original = signature.getSignature();
+		SignatureKey original = signature.getSignatureKey();
 		assertTrue(signature.confirmSignature(original.getTimestamp(), original.getSignature()));
 	}
 }


### PR DESCRIPTION
There were a few last minute comments on the last pr that I missed, they happened at the same time that I merged 🙈 

This PR changes the method name from `generateSignature` -> `getSignatureKey` 
Also changes the method name in the SignatureKey to `generateKey` -> `generate` 