### PR TITLE
Adding kyc_receipt and kyc_receipt fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 // Configure group ID, artifact ID, and version
 group = "com.smileidentity"
 archivesBaseName = "smile-identity-core"
-version = "2.1.3"
+version = "2.1.4"
 def apiVersion = "0.2.0"
 
 // Build, sign, and upload

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.1.4] - 2023-8-3
+* Updated JobStatusResponse to include kyc_receipt and kyb_receipt fields 
+
 ## [2.1.2] - 2023-3-20
 * Fix for Biometric KYC Jobs
 * 

--- a/src/main/java/smile/identity/core/IDApi.java
+++ b/src/main/java/smile/identity/core/IDApi.java
@@ -99,7 +99,7 @@ public class IDApi {
         JobResponse result = smileIdentityService.idVerification(request);
         return new JobStatusResponse(result.getResultCode(), true, true,
                 new JobStatusResponse.Result(result), result.getSignature(), result.getTimestamp(), null,
-                null);
+                null, "", "");
     }
 
     private EnhancedKYCRequest setupRequests(PartnerParams partnerParams,

--- a/src/main/java/smile/identity/core/models/JobStatusResponse.java
+++ b/src/main/java/smile/identity/core/models/JobStatusResponse.java
@@ -36,10 +36,16 @@ public class JobStatusResponse {
     Map<String, String> imageLinks;
 
     List<JobResponse> history;
+    
+    @Json(name = "kyc_receipt")
+    String kycReceipt;
+    
+    @Json(name = "kyb_receipt")
+    String kybReceipt;
 
     public JobStatusResponse(JobResponse result) {
         this("", false, true, new Result(result), result.getSignature(),
-                result.getTimestamp(), new HashMap<>(), new ArrayList<>());
+                result.getTimestamp(), new HashMap<>(), new ArrayList<>(), "", "");
     }
 
     @Value


### PR DESCRIPTION
We are currently not returning `kyc_receipt` or `kyb_receipt` fields from the job status endpoint. 

This PR adds the missing fields to the JobStatusResponse class. 
 