### PR TITLE
update readme file with usesmileid.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Smile Identity provides the best solutions for real time Digital KYC, identity verification, user onboarding, and user authentication across Africa. Our server side libraries make it easy to integrate us on the server-side. Since the library is server-side, you will be required to pass the images (if required) to the library.
 
 
- If you haven’t already, [sign up for a free Smile Identity account](https://www.smileidentity.com/schedule-a-demo/), which comes with Sandbox access.
+ If you haven’t already, [sign up for a free Smile Identity account](https://usesmileid.com/talk-to-an-expert), which comes with Sandbox access.
 
 
 Please see [changelog.md](https://github.com/smileidentity/smile-identity-core-java/blob/master/changelog.md). for release versions and changes
@@ -13,12 +13,12 @@ Please see [changelog.md](https://github.com/smileidentity/smile-identity-core-j
 The library exposes four classes namely; the WebApi class, the IDApi class, the Signature class, and the Utilities class.
 
 The WebApi class has the following public methods:
- - `submitJob` -  handles submission of any of Smile Identity products that requires an image i.e. [Biometric KYC](https://docs.smileidentity.com/products/biometric-kyc), [Document Verification](https://docs.smileidentity.com/products/document-verification), [SmartSelfieTM  Authentication](https://docs.smileidentity.com/products/biometric-authentication) and [Business Verification](https://docs.smileidentity.com/products/for-businesses-kyb/business-verification).
- - `getWebToken` - handles generation of web token, if you are using the [Hosted Web Integration](https://docs.smileidentity.com/web-mobile-web/web-integration-beta).
+ - `submitJob` -  handles submission of any of Smile Identity products that requires an image i.e. [Biometric KYC](https://docs.usesmileid.com/products/biometric-kyc), [Document Verification](https://docs.usesmileid.com/products/document-verification), [SmartSelfieTM  Authentication](https://docs.usesmileid.com/products/biometric-authentication) and [Business Verification](https://docs.usesmileid.com/products/for-businesses-kyb/business-verification).
+ - `getWebToken` - handles generation of web token, if you are using the [Hosted Web Integration](https://docs.usesmileid.com/web-mobile-web/web-integration-beta).
 
  The IDApi class has the following public method:
 
-- `submitJob` - handles submission of [Enhanced KYC](https://docs.smileidentity.com/products/identity-lookup) and [Basic KYC](https://docs.smileidentity.com/products/id-verification).
+- `submitJob` - handles submission of [Enhanced KYC](https://docs.usesmileid.com/products/identity-lookup) and [Basic KYC](https://docs.usesmileid.com/products/id-verification).
 
 The Signature class has the following public methods:
 
@@ -27,7 +27,7 @@ The Signature class has the following public methods:
 
 The Utilities Class allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 
-- `getJobStatus` - retrieve information & results of a job. Read more on job status in the [Smile Identity documentation](https://docs.smileidentity.com/further-reading/job-status).
+- `getJobStatus` - retrieve information & results of a job. Read more on job status in the [Smile Identity documentation](https://docs.usesmileid.com/further-reading/job-status).
 
 ## Installation
 
@@ -41,13 +41,13 @@ group: "com.smileidentity", name: "smile-identity-core", version: "<current-vers
 
 ## Documentation
 
-For extensive instructions on usage of the library and sample codes, please refer to the official Smile Identity [documentation](https://docs.smileidentity.com/server-to-server/java).
+For extensive instructions on usage of the library and sample codes, please refer to the official Smile Identity [documentation](https://docs.usesmileid.com/server-to-server/java).
 
 Before that, you should take a look at the examples in the [examples](/examples) folder.
 
 ## Getting Help
 
-For usage questions, the best resource is [our official documentation](https://docs.smileidentity.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.smileidentity.com/partner/support/tickets) or visit the [contact us page](https://portal.smileidentity.com/partner/support/tickets) on our website.
+For usage questions, the best resource is [our official documentation](https://docs.usesmileid.com). However, if you require further assistance, you can file a [support ticket via our portal](https://portal.usesmileid.com/partner/support/tickets) or visit the [contact us page](https://portal.usesmileid.com/partner/support/tickets) on our website.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

This PR revises our README file by replacing the deprecated smileID domain name from [smileidentity.com](http://smileidentity.com/) with [usesmileid.com](http://usesmileid.com/).

## Test Instructions

Ensure the updated links works as expected
