### PR TITLE
update domain name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,9 @@ publishing {
                     developer {
                         id = 'Support'
                         name = 'Smile Identity'
-                        email = 'support@smileidentity.com'
+                        email = 'support@usesmileid.com'
                         organization = 'Smile Identity'
-                        organizationUrl = 'https://www.smileidentity.com'
+                        organizationUrl = 'https://www.usesmileid.com'
                     }
                 }
             }

--- a/changelog.md
+++ b/changelog.md
@@ -54,7 +54,7 @@ All notable changes to this project will be documented in this file.
 * Fixed possible crash when  passing null callback_url to WebApi  class
 
 ## [1.0.4] - 2020-06-23
-* Allow more image_type_id specifically 4 and 6 for more information on this please see https://docs.smileidentity.com/products/web-api/core-libraries
+* Allow more image_type_id specifically 4 and 6 for more information on this please see https://docs.usesmileid.com/products/web-api/core-libraries
 * Also removed validations on id or selfie images
 
 ## [1.0.3] - 2020-05-29

--- a/examples/BiometricKYC.java
+++ b/examples/BiometricKYC.java
@@ -11,7 +11,7 @@ import smile.identity.core.models.PartnerParams;
 
 public class BiometricKYC {
 
-    // See https://docs.smileidentity.com/server-to-server/java/products/biometric-kyc
+    // See https://docs.usesmileid.com/server-to-server/java/products/biometric-kyc
     // for how to setup and retrieve configuation values for the WebApi class.
 
     public static main(String[] args) {

--- a/examples/DocumentVerification.java
+++ b/examples/DocumentVerification.java
@@ -8,7 +8,7 @@ import smile.identity.core.models.ImageDetail;
 
 public class DocumentVerification {
 
-    // See https://docs.smileidentity.com/server-to-server/java/products/document-verification for
+    // See https://docs.usesmileid.com/server-to-server/java/products/document-verification for
     // how to setup and retrieve configuation values for the WebApi class.
 
     public static main(String[] args) {


### PR DESCRIPTION
This PR updates smileidentity.com to usesmileid.com as part of the gradual transition to using the new domain name throughout the system.