### PR TITLE
fix(signature): use MessageDigest.isEqual for constant-time comparison and add rejection test

### DIFF
--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -4,6 +4,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Base64;
 
@@ -43,6 +44,8 @@ public class SignatureKey {
     }
 
     public boolean validSignature(String signature) {
-        return signature.equals(this.signature);
+        byte[] expected = this.signature.getBytes(StandardCharsets.UTF_8);
+        byte[] actual = signature.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expected, actual);
     }
 }

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -46,6 +46,11 @@ public class SignatureKey {
     public boolean validSignature(String signature) {
         byte[] expected = this.signature.getBytes(StandardCharsets.UTF_8);
         byte[] actual = signature.getBytes(StandardCharsets.UTF_8);
+
+        if (expected.length != actual.length) {
+            return false;
+        }
+
         return MessageDigest.isEqual(expected, actual);
     }
 }

--- a/src/main/java/smile/identity/core/keys/SignatureKey.java
+++ b/src/main/java/smile/identity/core/keys/SignatureKey.java
@@ -47,10 +47,6 @@ public class SignatureKey {
         byte[] expected = this.signature.getBytes(StandardCharsets.UTF_8);
         byte[] actual = signature.getBytes(StandardCharsets.UTF_8);
 
-        if (expected.length != actual.length) {
-            return false;
-        }
-
         return MessageDigest.isEqual(expected, actual);
     }
 }

--- a/src/test/java/smile/identity/core/SignatureTest.java
+++ b/src/test/java/smile/identity/core/SignatureTest.java
@@ -40,4 +40,11 @@ public class SignatureTest {
         String returnedSignature = "XxThLHZy2ij1WINkqNEPgzVs9RvUDHWlebDYzprqS74=";
         assertTrue(signature.confirmSignature(timestamp, returnedSignature));
     }
+
+    @Test
+    public void itRejectsAnInvalidSignature() {
+        Signature signature = new Signature("partner", "apiKey");
+        SignatureKey original = signature.getSignatureKey();
+        assertFalse(signature.confirmSignature(original.getTimestamp(), "invalidSignatureValue"));
+    }
 }


### PR DESCRIPTION
### **User description**
This pull request strengthens the security of signature comparison in the `SignatureKey` class and adds a new test to verify that invalid signatures are correctly rejected. The most important changes are:

**Security improvements:**

* Updated the `validSignature` method in `SignatureKey` to use `MessageDigest.isEqual` for constant-time signature comparison, reducing the risk of timing attacks.
* Imported `java.security.MessageDigest` to support the secure comparison.

**Testing enhancements:**

* Added a new test `itRejectsAnInvalidSignature` in `SignatureTest` to ensure that invalid signatures are properly rejected.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use `MessageDigest.isEqual` for constant-time signature comparison

- Add test to verify invalid signatures are rejected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validSignature method"] -- "before: String.equals" --> B["Timing attack vulnerable"]
  A -- "after: MessageDigest.isEqual" --> C["Constant-time comparison"]
  D["New test"] -- "verifies" --> E["Invalid signature rejected"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SignatureKey.java</strong><dd><code>Constant-time signature comparison to prevent timing attacks</code></dd></summary>
<hr>

src/main/java/smile/identity/core/keys/SignatureKey.java

<ul><li>Replaced <code>String.equals</code> with <code>MessageDigest.isEqual</code> for constant-time <br>byte comparison<br> <li> Added import for <code>java.security.MessageDigest</code><br> <li> Converts both signature strings to byte arrays using UTF-8 before <br>comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-java/pull/72/files#diff-c44d7bcc9327749eb7ef4aaf83d4e8aa042dc98a25512228c56ad8c32dbe54ea">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SignatureTest.java</strong><dd><code>Add test for invalid signature rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/smile/identity/core/SignatureTest.java

<ul><li>Added <code>itRejectsAnInvalidSignature</code> test to verify that an invalid <br>signature string is correctly rejected by <code>confirmSignature</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-java/pull/72/files#diff-246db98d44fe5bb787c879d4572cadcd510436f3c0a2de33c806813bdd2fd4f4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>