### PR TITLE
Add DefectDojo import step to Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:


### PR DESCRIPTION
### **User description**
## Summary
- Adds an "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, right after the existing GitHub Code Scanning SARIF upload step.
- Pushes the Semgrep SARIF results to DefectDojo (https://defectdojo.smile.id) via the `reimport-scan` API so findings get an aggregated view instead of only living in PR checks.
- Non-blocking: `if: always()` + `continue-on-error: true`, and the step exits cleanly (no failure) if `semgrep.sarif` doesn't exist or is empty.
- Uses the existing org-wide GitHub Actions secrets `DEFECTDOJO_URL` and `DEFECTDOJO_API_TOKEN` (already scoped to this repo) — no new secrets added.

This mirrors `smileidentity/lambda#4662` (same template), which is currently open/unmerged but has a proven-working pull_request-triggered CI run.

## SARIF filename used
This repo's Semgrep step runs:
```
semgrep scan --config p/security-audit --sarif -o semgrep.sarif
```
so the output file is `semgrep.sarif` — same filename as the lambda template, no adjustment needed. Please sanity-check this against the workflow before merging.

## Test plan
- [ ] Confirm CI runs the new step on this PR (pull_request trigger) and it completes (pass or gracefully skip) without blocking the required Semgrep checks.
- [ ] Confirm the scan shows up in DefectDojo under product `smile-identity-core-java`, product type `GitHub`, engagement `CI`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo SARIF import step to Semgrep workflow

- Pushes scan results via reimport-scan API for aggregated findings view

- Non-blocking with graceful skip when SARIF file is missing

- Uses existing org-wide secrets for authentication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] --> B["Upload SARIF to GitHub"]
  B --> C["Import to DefectDojo"]
  C --> D["Comment on PR"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add DefectDojo reimport-scan step to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Uses <code>curl</code> to POST <code>semgrep.sarif</code> to DefectDojo's <code>reimport-scan</code> API <br>endpoint<br> <li> Gracefully skips if <code>semgrep.sarif</code> is missing or empty<br> <li> Configured with <code>if: always()</code> and <code>continue-on-error: true</code> to be <br>non-blocking</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-java/pull/76/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>