### PR TITLE
Fix shell-injection risk in DefectDojo import step

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## Summary

The "Import results into DefectDojo" step in `.github/workflows/semgrep.yml` (added in #76) interpolates two GitHub Actions expressions directly into a `run: |` shell script via `${{ ... }}`:

- `${{ github.event.repository.name }}` in the `product_name=` field
- `${{ github.head_ref || github.ref_name }}` in the `branch_tag=` field

GitHub Actions substitutes `${{ }}` expressions into the script text **before** the shell runs it. `github.head_ref` is the PR's source branch name, which is attacker-controllable — git branch names can legally contain backticks and `$(...)`. A maliciously named branch on a pull request could therefore inject arbitrary shell commands into this CI job, which has access to `secrets.DEFECTDOJO_API_TOKEN` and a repo-scoped `GITHUB_TOKEN`.

This is a known GitHub Actions anti-pattern (CWE-78 — improper neutralization of special elements used in an OS command), previously flagged by `prfectionist[bot]` on the reference implementation PR [smileidentity/lambda#4662](https://github.com/smileidentity/lambda/pull/4662), from which the step added by #76 in this repo was copied.

## Fix

Route both values through the step's `env:` block instead of interpolating them directly into the shell script, and reference them as shell variables (`$REPO_NAME`, `$BRANCH_TAG`). Environment variable values are passed to the process environment rather than substituted into the script text, so shell metacharacters in the value can't be interpreted as script.

`${{ github.sha }}` (used for `commit_hash=`) is left untouched — it's a full commit SHA, not attacker-controlled content, so it poses no injection risk.

## Diff

```diff
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           ...
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             ...
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
```

## Test plan

- [x] Diffed the modified file against `main` to confirm only these four lines changed (two new `env:` keys, two `-F` line substitutions) — no other content touched.
- [ ] CI (Semgrep workflow) runs on this PR and the DefectDojo import step still succeeds with the new env-based variables.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix shell-injection vulnerability in DefectDojo import step

- Route attacker-controllable expressions through `env:` block

- Prevent arbitrary command execution via malicious branch names

- Reference values as shell variables instead of inline interpolation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Attacker-controlled branch name"] -- "previously injected into" --> B["Shell script via ${{ }}"]
  B -- "could execute" --> C["Arbitrary commands"]
  A -- "now passed safely via" --> D["env: block"]
  D -- "referenced as" --> E["Shell variable ${BRANCH_TAG}"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Move expressions to env block to prevent shell injection</code>&nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added <code>REPO_NAME</code> and <code>BRANCH_TAG</code> environment variables to the step's <br><code>env:</code> block<br> <li> Replaced inline <code>${{ github.event.repository.name }}</code> with <code>${REPO_NAME}</code> <br>in the shell script<br> <li> Replaced inline <code>${{ github.head_ref || github.ref_name }}</code> with <br><code>${BRANCH_TAG}</code> in the shell script</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-java/pull/77/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>